### PR TITLE
Translate nil to null in query params

### DIFF
--- a/lib/easybill_rest_client/request.rb
+++ b/lib/easybill_rest_client/request.rb
@@ -54,8 +54,23 @@ module EasybillRestClient
       return @uri if @uri
       @uri = URI.parse(BASE_URL)
       @uri.path << endpoint
-      @uri.query = URI.encode_www_form(comma_separate_arrays(params.dup)) unless body_allowed?
+      @uri.query = URI.encode_www_form(query_params) unless body_allowed?
       @uri
+    end
+
+    def query_params
+      params.map { |key, value| [key, translate_query_value(value)] }.to_h
+    end
+
+    def translate_query_value(value)
+      case value
+      when Array
+        value.join(',')
+      when nil
+        'null'
+      else
+        value
+      end
     end
 
     def request
@@ -72,10 +87,6 @@ module EasybillRestClient
 
     def body_allowed?
       request_class::REQUEST_HAS_BODY
-    end
-
-    def comma_separate_arrays(params)
-      params.map { |k, v| [k, v.is_a?(Array) ? v.join(',') : v] }.to_h
     end
 
     def retry_on(exception, &block)

--- a/spec/fixtures/vcr/EasybillRestClient_DocumentApi/_find_all/paid_and_unpaid_documents_exist/returns_only_unpaid_documents.yml
+++ b/spec/fixtures/vcr/EasybillRestClient_DocumentApi/_find_all/paid_and_unpaid_documents_exist/returns_only_unpaid_documents.yml
@@ -1,0 +1,615 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.easybill.de/rest/v1/customers
+    body:
+      encoding: UTF-8
+      string: '{"company_name":"ACME Corp.","emails":[],"last_name":"Mustermann"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: '{"acquire_options":null,"bank_account":null,"bank_account_owner":null,"bank_bic":null,"bank_code":null,"bank_iban":null,"bank_name":null,"birth_date":null,"cash_allowance":null,"cash_allowance_days":0,"cash_discount":null,"cash_discount_type":null,"city":null,"company_name":"ACME
+        Corp.","country":"DE","delivery_city":null,"delivery_company_name":null,"delivery_country":null,"delivery_first_name":null,"delivery_last_name":null,"delivery_personal":false,"delivery_salutation":0,"delivery_street":null,"delivery_suffix_1":null,"delivery_suffix_2":null,"delivery_zip_code":null,"emails":[],"fax":null,"first_name":null,"grace_period":null,"group_id":null,"id":75562448,"info_1":null,"info_2":null,"internet":null,"last_name":"Mustermann","login_id":20454,"mobile":null,"note":null,"number":"154213","payment_options":null,"personal":false,"phone_1":null,"phone_2":null,"postbox":null,"postbox_city":null,"postbox_country":null,"postbox_zip_code":null,"sale_price_level":null,"salutation":0,"sepa_agreement":null,"sepa_agreement_date":null,"sepa_mandate_reference":null,"since_date":null,"street":null,"suffix_1":null,"suffix_2":null,"tax_number":null,"tax_options":null,"title":null,"vat_identifier":null,"zip_code":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:21 GMT
+- request:
+    method: post
+    uri: https://api.easybill.de/rest/v1/documents
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":75562448,"items":[]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: '{"address":{"city":null,"company_name":"ACME Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":"","contact_text":"","created_at":"2016-07-20
+        17:26:21","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":null,"edited_at":"2016-07-20
+        17:26:21","grace_period":10,"id":91046858,"is_archive":false,"is_draft":true,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":null,"paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:22 GMT
+- request:
+    method: put
+    uri: https://api.easybill.de/rest/v1/documents/91046858/done
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"address":{"city":null,"company_name":"ACME Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":null,"contact_text":null,"created_at":"2016-07-20
+        17:26:21","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":"2016-07-30","edited_at":"2016-07-20
+        17:26:22","grace_period":10,"id":91046858,"is_archive":false,"is_draft":false,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":"C1607-17966","paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:22 GMT
+- request:
+    method: post
+    uri: https://api.easybill.de/rest/v1/document-payments
+    body:
+      encoding: UTF-8
+      string: '{"amount":0,"document_id":91046858}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: '{"amount":0,"document_id":91046858,"id":80467771,"login_id":20454,"notice":"","payment_at":"1970-01-01","type":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:22 GMT
+- request:
+    method: post
+    uri: https://api.easybill.de/rest/v1/documents
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":75562448,"items":[]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: '{"address":{"city":null,"company_name":"ACME Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":"","contact_text":"","created_at":"2016-07-20
+        17:26:22","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":null,"edited_at":"2016-07-20
+        17:26:23","grace_period":10,"id":91046861,"is_archive":false,"is_draft":true,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":null,"paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+- request:
+    method: put
+    uri: https://api.easybill.de/rest/v1/documents/91046861/done
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"address":{"city":null,"company_name":"ACME Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":null,"contact_text":null,"created_at":"2016-07-20
+        17:26:22","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":"2016-07-30","edited_at":"2016-07-20
+        17:26:23","grace_period":10,"id":91046861,"is_archive":false,"is_draft":false,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":"C1607-17967","paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+- request:
+    method: get
+    uri: https://api.easybill.de/rest/v1/documents?limit=1000&number=,C1607-17967&page=1&paid_at=null
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"pages":1,"limit":1000,"total":1,"items":[{"address":{"city":null,"company_name":"ACME
+        Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":null,"contact_text":null,"created_at":"2016-07-20
+        17:26:22","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":"2016-07-30","edited_at":"2016-07-20
+        17:26:23","grace_period":10,"id":91046861,"is_archive":false,"is_draft":false,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":"C1607-17967","paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}]}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+- request:
+    method: get
+    uri: https://api.easybill.de/rest/v1/documents?limit=1000&number=,C1607-17967&page=1&paid_at=null
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"pages":1,"limit":1000,"total":1,"items":[{"address":{"city":null,"company_name":"ACME
+        Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":null,"contact_text":null,"created_at":"2016-07-20
+        17:26:22","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":"2016-07-30","edited_at":"2016-07-20
+        17:26:23","grace_period":10,"id":91046861,"is_archive":false,"is_draft":false,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":"C1607-17967","paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}]}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+- request:
+    method: get
+    uri: https://api.easybill.de/rest/v1/documents?limit=1000&number=,C1607-17967&page=1&paid_at=null
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 15:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"pages":1,"limit":1000,"total":1,"items":[{"address":{"city":null,"company_name":"ACME
+        Corp.","country":"DE","first_name":null,"last_name":"Mustermann","personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"title":null,"zip_code":null},"amount":0,"amount_net":0,"bank_debit_form":null,"cancel_id":null,"cash_allowance":null,"cash_allowance_days":null,"cash_allowance_text":null,"contact_id":null,"contact_label":null,"contact_text":null,"created_at":"2016-07-20
+        17:26:22","currency":"EUR","customer_id":75562448,"discount":null,"discount_type":null,"document_date":"2016-07-20","due_date":"2016-07-30","edited_at":"2016-07-20
+        17:26:23","grace_period":10,"id":91046861,"is_archive":false,"is_draft":false,"items":[],"label_address":{"city":null,"company_name":null,"country":null,"first_name":null,"last_name":null,"personal":false,"salutation":0,"street":null,"suffix_1":null,"suffix_2":null,"zip_code":null},"last_postbox_id":null,"login_id":20454,"number":"C1607-17967","paid_amount":0,"paid_at":null,"pdf_pages":1,"pdf_template":null,"project_id":null,"ref_id":null,"service_date":{"type":"DEFAULT","date":"2016-07-20","date_from":null,"date_to":null,"text":null},"status":null,"text":"Vielen
+        Dank f\u00fcr Ihren Auftrag!\n\nBitte begleichen Sie den offenen Betrag bis
+        zum %DOKUMENT.DATUM-FAELLIG%.\n\nMit freundlichen Gr\u00fc\u00dfen\n\n%FIRMA.FIRMA%\n","text_prefix":"%KUNDE.ANREDE%,\nnachfolgend
+        berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}]}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/EasybillRestClient_DocumentApi/_find_all/paid_and_unpaid_documents_exist/returns_only_unpaid_documents.yml
+++ b/spec/fixtures/vcr/EasybillRestClient_DocumentApi/_find_all/paid_and_unpaid_documents_exist/returns_only_unpaid_documents.yml
@@ -612,4 +612,184 @@ http_interactions:
         berechnen wir Ihnen wie vorab besprochen:\n","title":null,"type":"INVOICE","use_shipping_address":false,"vat_option":null}]}'
     http_version: 
   recorded_at: Wed, 20 Jul 2016 15:26:23 GMT
+- request:
+    method: delete
+    uri: https://api.easybill.de/rest/v1/documents/91046858
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 16:06:07 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 16:06:07 GMT
+- request:
+    method: delete
+    uri: https://api.easybill.de/rest/v1/documents/91046861
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 16:06:08 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 16:06:08 GMT
+- request:
+    method: delete
+    uri: https://api.easybill.de/rest/v1/customers/75562448
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.easybill.de
+      Authorization:
+      - Basic easybill-basic-auth-key
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 20 Jul 2016 16:11:21 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self'' *.easybill.de *.paymill.de *.paymill.com;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' *.paymill.de *.paymill.com
+        *.google-analytics.com *.googleadservices.com d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: *.doubleclick.net notify.bugsnag.com *.paypalobjects.com
+        online.swagger.io *.google-analytics.com *.google.com *.google.de *.google.at
+        *.google.ch; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src
+        ''self'' themes.googleusercontent.com fonts.gstatic.com; frame-src ''self''
+        *.googleadservices.com ssl.kaptcha.com *.paymill.de *.paymill.com *.mediafinanz.de
+        *.google.de *.google.com *.google.at *.google.ch *.doubleclick.net player.vimeo.com
+        *.facebook.com; object-src ''self'''
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 16:11:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/integration/easybill_rest_client/document_api_spec.rb
+++ b/spec/integration/easybill_rest_client/document_api_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe EasybillRestClient::DocumentApi, :vcr do
         d
       end
 
+      after do
+        subject.delete(paid_document.id)
+        subject.delete(unpaid_document.id)
+        client.customers.delete(customer.id)
+      end
+
       it 'returns only unpaid documents' do
         documents = subject.find_all(paid_at: nil,
                                      number: [paid_document.number, unpaid_document.number])


### PR DESCRIPTION
Some query params can be used to filter requested entities by a value
not being set. E.g. unpaid documents can be requested with
`paid_at=null`. With this change we encapsulate that knowledge and let
the user use `nil` instead of `'null'`.