### PR TITLE
Log the whole response body on error

### DIFF
--- a/lib/easybill_rest_client/response.rb
+++ b/lib/easybill_rest_client/response.rb
@@ -8,8 +8,7 @@ module EasybillRestClient
     def body
       body = extract_response_body(response)
       unless response.is_a?(Net::HTTPSuccess)
-        message = body.is_a?(Hash) ? body[:message] : body
-        raise ApiError, message
+        raise ApiError, body.inspect
       end
       body && !body.empty? ? body : nil
     end

--- a/spec/integration/easybill_rest_client/document_api_spec.rb
+++ b/spec/integration/easybill_rest_client/document_api_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe EasybillRestClient::DocumentApi, :vcr do
       expect(api.find(84718807)).not_to be_nil
       expect(api.delete(84718807)).to be_nil
       expect { api.find(84718807) }
-        .to raise_error(EasybillRestClient::ApiError, 'Document#84718807 not found.')
+        .to raise_error(EasybillRestClient::ApiError, /Document#84718807 not found./)
     end
   end
 

--- a/spec/integration/easybill_rest_client/document_payment_api_spec.rb
+++ b/spec/integration/easybill_rest_client/document_payment_api_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe EasybillRestClient::DocumentPaymentApi, :vcr do
       expect(api.find(74692458)).to be_a(EasybillRestClient::DocumentPayment)
       expect(api.delete(74692458)).to be_nil
       expect { api.find(74692458) }
-        .to raise_error(EasybillRestClient::ApiError, 'DocumentPayment#74692458 not found.')
+        .to raise_error(EasybillRestClient::ApiError, /DocumentPayment#74692458 not found./)
     end
   end
 

--- a/spec/integration/easybill_rest_client/post_box_api_spec.rb
+++ b/spec/integration/easybill_rest_client/post_box_api_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EasybillRestClient::PostBoxApi, :vcr do
       api.find(58942178)
       api.delete(58942178)
       expect { api.find(58942178) }
-        .to raise_error(EasybillRestClient::ApiError, 'PostBox#58942178 not found.')
+        .to raise_error(EasybillRestClient::ApiError, /PostBox#58942178 not found./)
     end
   end
 end


### PR DESCRIPTION
Sometimes the error message is empty, let's figure out why.