### PR TITLE
Work around exception on Easybill's side

### DIFF
--- a/lib/easybill_rest_client/document_api.rb
+++ b/lib/easybill_rest_client/document_api.rb
@@ -6,7 +6,7 @@ module EasybillRestClient
   class DocumentApi < GenericApi
     # This works around an issue on Easybill's side, where they throw an
     # exception about an item's `id` being `null`, which only seems to go away
-    # if we compact the whole hash. 🤷
+    # if we compact the whole hash.
     def create(entity)
       attributes = entity.attributes
       attributes[:items] = entity.items.map { |item| item.attributes.compact }

--- a/lib/easybill_rest_client/document_api.rb
+++ b/lib/easybill_rest_client/document_api.rb
@@ -4,6 +4,15 @@ require 'easybill_rest_client/generic_api'
 
 module EasybillRestClient
   class DocumentApi < GenericApi
+    # This works around an issue on Easybill's side, where they throw an
+    # exception about an item's `id` being `null`, which only seems to go away
+    # if we compact the whole hash. 🤷
+    def create(entity)
+      attributes = entity.attributes
+      attributes[:items] = entity.items.map { |item| item.attributes.compact }
+      build(api_client.request(:post, "/#{resource_name}", attributes))
+    end
+
     def resource_name
       'documents'
     end


### PR DESCRIPTION
When creating a document, the API returns an exception, if there are `null` values in the document's `items`.

🔗 [bugsnag](https://app.bugsnag.com/ad2games/backoffice/errors/5b362c957a2ab400197026a4)